### PR TITLE
Разделение двух команд на две линии

### DIFF
--- a/Lab3_static/Stack.cpp
+++ b/Lab3_static/Stack.cpp
@@ -76,7 +76,8 @@ namespace Stack_static {
 			s << "empty";
 		else {
 			for (int i = st.top - 1; i > 0; --i)
-				s << st.a[i] << '|'; s << st.a[0];
+				s << st.a[i] << '|'; 
+				s << st.a[0];
 		}
 		return s;
 	}


### PR DESCRIPTION
Желательно каждую команду выделять в отдельной линий если они не взаимосвязаны друг с другом.
Просто делает код более читабельным.