### PR TITLE
n>=0

### DIFF
--- a/Lab3_static/Stack.cpp
+++ b/Lab3_static/Stack.cpp
@@ -21,7 +21,7 @@ namespace Stack_static {
 
 	Stack::Stack(const Cell c[], int n) : top(0)
 	{
-		if ((0 <= n) && (n <= SZ))
+		if ((n>=0) && (n <= SZ))
 			while(top < n)
 				a[top] = c[top++];
 		else throw std::exception("Int parametr is out of range!");


### PR DESCRIPTION
Правильнее будет писать давая приоритет левосторонности переменной, так как это
1) Упрощает понимание для других разработчиков
2)Убирает двоякость и потенциальные неправильные интерпретации выражения компилятором